### PR TITLE
feat: add regex support to Find & Replace

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -416,10 +416,11 @@ After ContentView refactoring, verify:
 
 3. **Regex Support in Find & Replace** ✅
    - Toggle to enable regex mode in Find & Replace step
-   - Support for capture groups ($1, $2, etc. in replacement)
+   - Support for capture groups ($0 for full match, $1, $2, etc. in replacement)
    - Case-insensitive matching
-   - Graceful handling of invalid regex patterns
-   - 6 new unit tests for regex functionality
+   - Graceful handling of invalid regex patterns and templates
+   - Pre-compiled regex caching for batch performance
+   - 9 new unit tests for regex functionality
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -400,28 +400,37 @@ After ContentView refactoring, verify:
 
 ---
 
-## 🔮 Future Enhancements (After This PR)
+## ✅ Phase 5: Additional Features (IN PROGRESS)
 
-Once the architecture refactoring is complete, these become much easier:
+### Completed:
 
-1. **Unit Testing**
-   - Test RenamingEngine with various step combinations
-   - Test FileProcessingService with mocked FileManager
-   - Test BookmarkManager bookmark lifecycle
-   - Test ViewModels with mocked services
+1. **Unit Testing** ✅
+   - 74 unit tests covering RenamingEngine, FileProcessingService, ViewModels, and models
+   - Isolated UserDefaults for test independence
+   - Comprehensive coverage of edge cases
 
-2. **Better Error Handling**
-   - Structured error types throughout
+2. **Better Error Handling** ✅
+   - `FileProcessingErrorKind` enum for structured error types
+   - `fileId` on errors for stable correlation
    - User-friendly error messages
-   - Error recovery flows
 
-3. **Improved Accessibility**
+3. **Regex Support in Find & Replace** ✅
+   - Toggle to enable regex mode in Find & Replace step
+   - Support for capture groups ($1, $2, etc. in replacement)
+   - Case-insensitive matching
+   - Graceful handling of invalid regex patterns
+   - 6 new unit tests for regex functionality
+
+---
+
+## 🔮 Future Enhancements
+
+1. **Improved Accessibility**
    - VoiceOver labels and hints
    - Keyboard shortcuts
    - High contrast support
 
-4. **Additional Features**
-   - Regex support in Find & Replace
+2. **Additional Features**
    - Batch preview/confirmation screen
    - Filename templates
    - History/undo system
@@ -449,6 +458,6 @@ Once the architecture refactoring is complete, these become much easier:
 
 ---
 
-**Branch**: `refactor-architecture-viewmodels`
-**Status**: Phase 1 & 2 complete, Phase 3 ready to begin
-**Last Updated**: 2026-02-06
+**Branch**: `feature/regex-find-replace`
+**Status**: Phases 1-4 complete, Phase 5 in progress
+**Last Updated**: 2026-02-08

--- a/Scrubby/Models/Models.swift
+++ b/Scrubby/Models/Models.swift
@@ -47,7 +47,7 @@ public enum SequentialNumberPosition: String, Codable, CaseIterable, Equatable {
 
 // MARK: - RenamingStepType
 public enum RenamingStepType: Equatable {
-    case findReplace(find: String, replace: String)
+    case findReplace(find: String, replace: String, isRegex: Bool = false)
     case prefix(String)
     case suffix(String)
     case fileFormat(FileFormat)
@@ -73,7 +73,7 @@ extension RenamingStep: Codable {
     }
     
     enum StepTypeCodingKeys: String, CodingKey {
-        case kind, find, replace, value, format, start, minDigits, position
+        case kind, find, replace, isRegex, value, format, start, minDigits, position
     }
     
     enum StepKind: String, Codable {
@@ -87,10 +87,11 @@ extension RenamingStep: Codable {
         var typeContainer = container.nestedContainer(keyedBy: StepTypeCodingKeys.self, forKey: .type)
         
         switch type {
-        case .findReplace(let find, let replace):
+        case .findReplace(let find, let replace, let isRegex):
             try typeContainer.encode(StepKind.findReplace, forKey: .kind)
             try typeContainer.encode(find, forKey: .find)
             try typeContainer.encode(replace, forKey: .replace)
+            try typeContainer.encode(isRegex, forKey: .isRegex)
         case .prefix(let value):
             try typeContainer.encode(StepKind.prefix, forKey: .kind)
             try typeContainer.encode(value, forKey: .value)
@@ -122,7 +123,8 @@ extension RenamingStep: Codable {
         case .findReplace:
             let find = try typeContainer.decode(String.self, forKey: .find)
             let replace = try typeContainer.decode(String.self, forKey: .replace)
-            type = .findReplace(find: find, replace: replace)
+            let isRegex = try typeContainer.decodeIfPresent(Bool.self, forKey: .isRegex) ?? false
+            type = .findReplace(find: find, replace: replace, isRegex: isRegex)
         case .prefix:
             let value = try typeContainer.decode(String.self, forKey: .value)
             type = .prefix(value)

--- a/Scrubby/ViewModels/FileProcessingViewModel.swift
+++ b/Scrubby/ViewModels/FileProcessingViewModel.swift
@@ -173,6 +173,9 @@ class FileProcessingViewModel: ObservableObject {
         let currentRenamingSteps = renamingSteps
         let service = fileProcessingService
         
+        // Pre-compile regex steps for batch efficiency
+        let compiledRegex = RenamingEngine.compileRegexSteps(currentRenamingSteps)
+        
         // Resolve bookmarks on main thread with allowUI: true for user-initiated flows
         // This allows system UI prompts for permission re-grants
         var filesToProcess: [(source: URL, destinationName: String, fileId: UUID)] = []
@@ -198,7 +201,8 @@ class FileProcessingViewModel: ObservableObject {
                 let newName = RenamingEngine.processFileName(
                     selectedFile.fileName,
                     at: index,
-                    with: currentRenamingSteps
+                    with: currentRenamingSteps,
+                    compiledRegex: compiledRegex
                 )
                 filesToProcess.append((source: resolved.url, destinationName: newName, fileId: selectedFile.id))
                 

--- a/Scrubby/ViewModels/FileProcessingViewModel.swift
+++ b/Scrubby/ViewModels/FileProcessingViewModel.swift
@@ -33,10 +33,20 @@ class FileProcessingViewModel: ObservableObject {
     // MARK: - Published State
     
     @Published var selectedFiles: [SelectedFile] = []
-    @Published var renamingSteps: [RenamingStep] = [RenamingStep(type: .fileFormat(.none))]
+    @Published var renamingSteps: [RenamingStep] = [RenamingStep(type: .fileFormat(.none))] {
+        didSet {
+            // Invalidate regex cache when steps change
+            cachedCompiledRegex = nil
+        }
+    }
     @Published var overwrite: Bool = false
     @Published var moveFiles: Bool = false
     @Published var destinationFolderURL: URL? = nil
+    
+    // MARK: - Private State
+    
+    /// Cached compiled regex for preview performance
+    private var cachedCompiledRegex: [UUID: CompiledRegexStep]?
     
     // MARK: - Services
     
@@ -156,10 +166,16 @@ class FileProcessingViewModel: ObservableObject {
     ///   - index: The index of this file in the batch
     /// - Returns: The processed filename
     func previewFileName(for file: SelectedFile, at index: Int) -> String {
+        // Lazily compile regex cache for preview performance
+        if cachedCompiledRegex == nil {
+            cachedCompiledRegex = RenamingEngine.compileRegexSteps(renamingSteps)
+        }
+        
         return RenamingEngine.processFileName(
             file.fileName,
             at: index,
-            with: renamingSteps
+            with: renamingSteps,
+            compiledRegex: cachedCompiledRegex
         )
     }
     

--- a/Scrubby/Views/RenamingStepRow.swift
+++ b/Scrubby/Views/RenamingStepRow.swift
@@ -76,7 +76,7 @@ struct RenamingStepRow: View {
                             .cornerRadius(6)
                         }
                         if isRegex {
-                            Text("Use $1, $2, etc. in template for capture groups")
+                            Text("Use $0 for full match, $1, $2, etc. for capture groups")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }

--- a/Scrubby/Views/RenamingStepRow.swift
+++ b/Scrubby/Views/RenamingStepRow.swift
@@ -39,30 +39,46 @@ struct RenamingStepRow: View {
                     .padding(8)
                 }
                 switch step.type {
-                case .findReplace(let find, let replace):
+                case .findReplace(let find, let replace, let isRegex):
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Find & Replace").font(.headline)
                         HStack {
-                            TextField("Find", text: Binding(
+                            Text("Find & Replace").font(.headline)
+                            Spacer()
+                            Toggle("Regex", isOn: Binding(
+                                get: { isRegex },
+                                set: { newValue in
+                                    step.type = .findReplace(find: find, replace: replace, isRegex: newValue)
+                                }
+                            ))
+                            .toggleStyle(.checkbox)
+                            .font(.subheadline)
+                        }
+                        HStack {
+                            TextField(isRegex ? "Pattern" : "Find", text: Binding(
                                 get: { find },
                                 set: { newValue in
-                                    step.type = .findReplace(find: newValue, replace: replace)
+                                    step.type = .findReplace(find: newValue, replace: replace, isRegex: isRegex)
                                 }
                             ))
                             .onDrop(of: [UTType.text], isTargeted: nil) { _ in false }
                             .padding(6)
                             .background(Color(NSColor.quaternarySystemFill))
                             .cornerRadius(6)
-                            TextField("Replace", text: Binding(
+                            TextField(isRegex ? "Template" : "Replace", text: Binding(
                                 get: { replace },
                                 set: { newValue in
-                                    step.type = .findReplace(find: find, replace: newValue)
+                                    step.type = .findReplace(find: find, replace: newValue, isRegex: isRegex)
                                 }
                             ))
                             .onDrop(of: [UTType.text], isTargeted: nil) { _ in false }
                             .padding(6)
                             .background(Color(NSColor.quaternarySystemFill))
                             .cornerRadius(6)
+                        }
+                        if isRegex {
+                            Text("Use $1, $2, etc. in template for capture groups")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
                         }
                     }
                 case .prefix(let value):
@@ -233,7 +249,7 @@ struct RenamingStepRow: View {
 
 #Preview {
     struct RenamingStepRowPreviews: View {
-        @State var findReplaceStep = RenamingStep(type: .findReplace(find: "FindText", replace: "ReplaceText"))
+        @State var findReplaceStep = RenamingStep(type: .findReplace(find: "FindText", replace: "ReplaceText", isRegex: false))
         @State var prefixStep = RenamingStep(type: .prefix("PRE_"))
         @State var suffixStep = RenamingStep(type: .suffix("_SUF"))
         @State var fileFormatStep = RenamingStep(type: .fileFormat(.camelCased))


### PR DESCRIPTION
## Summary
- Add regex mode toggle to the Find & Replace renaming step
- Support capture groups ($1, $2, etc.) in replacement template
- Handle invalid regex patterns gracefully

## Changes
- **Models.swift**: Added `isRegex: Bool` parameter to `RenamingStepType.findReplace`
- **RenamingEngine.swift**: Added regex replacement logic using `NSRegularExpression`
- **RenamingStepRow.swift**: Added Regex checkbox toggle with helpful hint text
- **ScrubbyTests.swift**: Added new unit tests for regex functionality

## How It Works
When the "Regex" checkbox is enabled:
- The "Find" field accepts regular expression patterns
- The "Replace" field accepts template strings with capture group references
- Example: Pattern `(\w+)-(\w+)` with template `$2_$1` transforms `hello-world` to `world_hello`

## Test plan
- [x] Project builds without errors
- [x] All 74 unit tests pass
- [ ] Manual testing: Add Find & Replace step, toggle Regex on, test with patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)